### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,6 @@
 name: MyPy
+permissions:
+  contents: read
 
 on: [push]
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,9 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   pylint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jira-assistant/jira-assistant/security/code-scanning/1](https://github.com/jira-assistant/jira-assistant/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since the workflow only needs to read repository contents to check out the code, the `contents: read` permission is sufficient. This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

The `permissions` block should be added immediately after the `name` field in the workflow file to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
